### PR TITLE
Handle UnicodeDecodeError for JPG downloads

### DIFF
--- a/onfido/rest.py
+++ b/onfido/rest.py
@@ -218,7 +218,12 @@ class RESTClientObject(object):
             # In the python 3, the response.data is bytes.
             # we need to decode it to string.
             if six.PY3:
-                r.data = r.data.decode('utf8')
+                try:
+                    r.data = r.data.decode('utf8')
+                except UnicodeDecodeError:
+                    # If the data is a JPG, or other binary stream, it may begin
+                    # with 0xff which is invalid UTF-8 data.
+                    pass
 
             # log response body
             logger.debug("response body: %s", r.data)


### PR DESCRIPTION
JPG headers are `FF D8 FF`, and 0xff is an invalid start byte for UTF-8
sequences.